### PR TITLE
Replace deprecated percy/exec-action with direct test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run tests
-        uses: percy/exec-action@v0.3.1
-        with:
-          custom-command: "npm test"
+        run: npm test
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: v1/${{ runner.os }}/node-18/${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
## What
Replaces the `percy/exec-action@v0.3.1` step in `.github/workflows/test.yml` with a plain `run:` step that invokes the existing test command directly.

## Why
- **`percy/exec-action` no longer exists** — the repo 404s, so this workflow is currently broken.
- The repo's `test` script **already runs `percy exec` internally**, so wrapping it in `percy/exec-action` (which runs `percy exec -- <cmd>`) nested two Percy sessions.
- `@percy/cli` is already a devDependency, so the test command resolves `percy exec` on its own.

Net effect: removes the dead action and the double-wrap; the test runs exactly as intended with `PERCY_TOKEN` still passed through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)